### PR TITLE
Make the path where the client looks for views configurable

### DIFF
--- a/lib/graphql/client/railtie.rb
+++ b/lib/graphql/client/railtie.rb
@@ -40,7 +40,7 @@ module GraphQL
       initializer "graphql.configure_views_namespace" do |app|
         require "graphql/client/view_module"
 
-        path = app.paths["app/views"].first
+        path = config.graphql.views_path || app.paths["app/views"].first
 
         config.watchable_dirs[path] = [:erb]
 

--- a/lib/graphql/client/railtie.rb
+++ b/lib/graphql/client/railtie.rb
@@ -40,7 +40,7 @@ module GraphQL
       initializer "graphql.configure_views_namespace" do |app|
         require "graphql/client/view_module"
 
-        path = config.graphql.views_path || app.paths["app/views"].first
+        path = Rails.application.config.graphql_client_views_path || app.paths["app/views"].first
 
         config.watchable_dirs[path] = [:erb]
 

--- a/lib/graphql/client/railtie.rb
+++ b/lib/graphql/client/railtie.rb
@@ -42,11 +42,14 @@ module GraphQL
 
         path = config.graphql.client_views_path || app.paths["app/views"].first
 
+        client = config.graphql.client
+
         config.watchable_dirs[path] = [:erb]
 
         Object.const_set(:Views, Module.new do
           extend GraphQL::Client::ViewModule
           self.path = path
+          self.client = client
         end)
       end
     end

--- a/lib/graphql/client/railtie.rb
+++ b/lib/graphql/client/railtie.rb
@@ -37,12 +37,14 @@ module GraphQL
         end
       end
 
-      initializer "graphql.configure_views_namespace" do |app|
+      config.after_initialize do |app|
         require "graphql/client/view_module"
 
-        path = Rails.application.config.graphql_client_views_path || app.paths["app/views"].first
+        paths = [app.paths["app/views"].first, config.graphql.client_view_paths].flatten.uniq.compact
 
-        config.watchable_dirs[path] = [:erb]
+        paths.each do |path|
+          config.watchable_dirs[path] = [:erb]
+        end
 
         Object.const_set(:Views, Module.new do
           extend GraphQL::Client::ViewModule

--- a/lib/graphql/client/railtie.rb
+++ b/lib/graphql/client/railtie.rb
@@ -40,11 +40,9 @@ module GraphQL
       config.after_initialize do |app|
         require "graphql/client/view_module"
 
-        paths = [app.paths["app/views"].first, config.graphql.client_view_paths].flatten.uniq.compact
+        path = config.graphql.client_views_path || app.paths["app/views"].first
 
-        paths.each do |path|
-          config.watchable_dirs[path] = [:erb]
-        end
+        config.watchable_dirs[path] = [:erb]
 
         Object.const_set(:Views, Module.new do
           extend GraphQL::Client::ViewModule

--- a/lib/graphql/client/view_module.rb
+++ b/lib/graphql/client/view_module.rb
@@ -17,6 +17,8 @@ module GraphQL
     #   Views::Users::Show::UserFragment
     #
     module ViewModule
+      attr_accessor :client
+
       # Public: Extract GraphQL section from ERB template.
       #
       # src - String ERB text
@@ -103,10 +105,11 @@ module GraphQL
         query, lineno = ViewModule.extract_graphql_section(contents)
         return unless query
 
-        mod = Rails.application.config.graphql.client.parse(query, path, lineno)
+        mod = client.parse(query, path, lineno)
         mod.extend(ViewModule)
         mod.load_path = File.join(load_path, pathname)
         mod.source_path = path
+        mod.client = client
         mod
       end
 
@@ -117,6 +120,7 @@ module GraphQL
         Module.new.tap do |mod|
           mod.extend(ViewModule)
           mod.load_path = dirname
+          mod.client = client
         end
       end
 


### PR DESCRIPTION
In this pr we will make the path where the client looks for views configurable so we can place them somewhere else than in `app/views`